### PR TITLE
Update e2e tests to avoid use of timeout

### DIFF
--- a/client/cypress/e2e/add-user.cy.ts
+++ b/client/cypress/e2e/add-user.cy.ts
@@ -115,15 +115,19 @@ describe('Add user', () => {
       // to check.
       cy.intercept('/api/users').as('addUser');
       page.addUser(user);
-      cy.wait('@addUser');
+      cy.wait('@addUser').then(({response}) => {
+        expect(response.statusCode).to.eq(201);
+        expect(cy.url().should('match', /\/users\/[0-9a-fA-F]{24}$/));
+        expect(cy.url().should('not.match', /\/users\/new$/));
+      });
 
       // New URL should end in the 24 hex character Mongo ID of the newly added user.
       // We'll wait up to five full minutes for this these `should()` assertions to succeed.
       // Hopefully that long timeout will help ensure that our Cypress tests pass in
       // GitHub Actions, where we're often running on slow VMs.
-      cy.url({ timeout: 300000 })
-        .should('match', /\/users\/[0-9a-fA-F]{24}$/)
-        .should('not.match', /\/users\/new$/);
+      // cy.url({ timeout: 300000 })
+      //   .should('match', /\/users\/[0-9a-fA-F]{24}$/)
+      //   .should('not.match', /\/users\/new$/);
 
       // The new user should have all the same attributes as we entered
       cy.get('.user-card-name').should('have.text', user.name);


### PR DESCRIPTION
Used to be:
```
cy.wait('@addUser');

      // New URL should end in the 24 hex character Mongo ID of the newly added user.
      // We'll wait up to five full minutes for this these `should()` assertions to succeed.
      // Hopefully that long timeout will help ensure that our Cypress tests pass in
      // GitHub Actions, where we're often running on slow VMs.
      cy.url({ timeout: 300000 })
        .should('match', /\/users\/[0-9a-fA-F]{24}$/)
        .should('not.match', /\/users\/new$/);
```
Not totally sure if the timeout can be removed, but maybe putting these in a "then" will mean we don't need the timeout.